### PR TITLE
feat: set environment variable in workflow

### DIFF
--- a/client/src/api/getNewExpression.tsx
+++ b/client/src/api/getNewExpression.tsx
@@ -28,12 +28,10 @@ export const GetNewExpression = () => {
     isLoading: true,
   });
 
-  const API_URL = config.API_URL;
-
   useEffect(() => {
     const fetchExpression = async () => {
       try {
-        const response = await axios.get(`${API_URL}/get`);
+        const response = await axios.get(`${config.API_URL}/get`);
         setExpression({
           expression: parseExpression(response.data),
           isLoading: false,

--- a/client/src/utils/config.ts
+++ b/client/src/utils/config.ts
@@ -1,10 +1,3 @@
-const notNull = <T>(value: T | undefined | null, name: string): T => {
-  if (value == null) {
-    throw new TypeError(`${name} cannot be nullable! Value: ${value}`);
-  }
-  return value;
-};
-
 export const config = {
-  API_URL: notNull(import.meta.env.VITE_API_URL, "meta.env.VITE_API_URL"),
-} as const;
+  API_URL: import.meta.env.VITE_SERVER_URL,
+};


### PR DESCRIPTION
We cant rely on a local .env for the variables to be set in vercel dynamically.
This PR lets us use .env locally, and set API_URL variables from github secrets in workflow, when in production.
Must be deployed to test.