### PR TITLE
improved loading screen

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -25,7 +25,11 @@ function App() {
       </DisplaySidebarProvider>
       <main className="flex flex-col mx-40">
         {isLoading || !expression ? (
-          <h1>Loading...</h1>
+          <Expression
+            word={"Et kult uttrykk laster inn..."}
+            example={`"Her kommer det et eksempel på bruk av utrykket"`}
+            explanation={"Og en forklaring på hva uttrykket betyr"}
+          />
         ) : (
           <Expression
             word={expression.expression}


### PR DESCRIPTION
Changed the loading screen from a misplaced text: "loading...", to this:

![image](https://github.com/MarkusJohansen/dagens-ord/assets/90006516/29528e8d-cc12-4633-897b-6a3b8aa64bd7)
