### PR TITLE
Reset form, fix text input shade

### DIFF
--- a/client/src/components/suggestion-form.tsx
+++ b/client/src/components/suggestion-form.tsx
@@ -14,8 +14,15 @@ export const SuggestionForm = () => {
     definition: explanation,
   });
 
+  const onFormSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    setWord("");
+    setExample("");
+    setExplanation("");
+  }
+
   return (
-    <div className="flex flex-col gap-2">
+    <form className="flex flex-col gap-2" onSubmit={onFormSubmit}>
       <label htmlFor="word">
         Ord eller uttrykk:
         <input
@@ -24,11 +31,11 @@ export const SuggestionForm = () => {
           placeholder="En vinge"
           value={word}
           onChange={(e) => setWord(e.target.value)}
-          className="placeholder:text-light-gray border-black"
+          className="placeholder:text-light-gray border-black focus:shadow-xl"
           style={{ background: color }}
         />
       </label>
-      <label htmlFor="example" className="">
+      <label htmlFor="example">
         Eksempel:
         <input
           type="text"
@@ -36,11 +43,11 @@ export const SuggestionForm = () => {
           placeholder="Skal du ha deg en vinge eller?"
           value={example}
           onChange={(e) => setExample(e.target.value)}
-          className="placeholder:text-light-gray border-black"
+          className="placeholder:text-light-gray border-black focus:shadow-xl"
           style={{ background: color }}
         />
       </label>
-      <label htmlFor="explanation" className="">
+      <label htmlFor="explanation">
         Forklaring:
         <input
           type="text"
@@ -48,13 +55,13 @@ export const SuggestionForm = () => {
           placeholder="Et hardt slag"
           value={explanation}
           onChange={(e) => setExplanation(e.target.value)}
-          className="placeholder:text-light-gray border-black"
+          className="placeholder:text-light-gray border-black focus:shadow-xl"
           style={{ background: color }}
         />
       </label>
-      <button style={{ color: color }} onClick={() => suggest()}>
+      <button style={{ color: color }} className="focus:shadow-xl" onClick={() => suggest()}>
         Send inn forslag
       </button>
-    </div>
+    </form>
   );
 };


### PR DESCRIPTION
The form is now reset on send, it is also changed to a form element in html. Thought the purple shadow was ugly so changed that as well

Before:
![image](https://github.com/user-attachments/assets/29062564-ee6b-471c-b095-9cf594551241)


After:
![image](https://github.com/user-attachments/assets/249ea9bc-e4fe-4b1f-9e71-4b31390c625f)
